### PR TITLE
Adjust worker ID to start at 0 for Vitest v4

### DIFF
--- a/packages/vitest-environment-puppeteer/src/browsers.ts
+++ b/packages/vitest-environment-puppeteer/src/browsers.ts
@@ -67,8 +67,8 @@ const getJestWorkerId = (): number => {
 };
 
 const getWorkerIndex = () => {
-  // Jest worker ID starts at 1
-  return getJestWorkerId() - 1;
+  // Worker ID starts at 0 from Vitest v4 onwards
+  return getJestWorkerId();
 };
 
 const getWorkerWsEndpointIndex = () => {


### PR DESCRIPTION
Previously Vitest worker Ids were 1-based;rom v4 they are 0-based?

(At a quick glance it seems that what was previously ++workerId is now workerId++)

https://github.com/vitest-dev/vitest/blob/9dc18673739a0d6e38a40574fbb9a5cc048cf2a7/packages/vitest/src/node/pools/forks.ts#L135

vs

https://github.com/vitest-dev/vitest/blob/ede1f39d60458f9ec1a98cf72b290677d65a7d80/packages/vitest/src/node/pool.ts#L156

See #12 
