### PR TITLE
Rename transformMode to viteEnvironment in PuppeteerEnvironment

### DIFF
--- a/packages/vitest-environment-puppeteer/src/env.ts
+++ b/packages/vitest-environment-puppeteer/src/env.ts
@@ -134,7 +134,7 @@ const closeAll = async (global: StrictGlobal) => {
 
 export const PuppeteerEnvironment = <Environment>{
   name: "puppeteer",
-  transformMode: "ssr",
+  viteEnvironment: "ssr",
   async setup(global) {
     global.puppeteerConfig = await readConfig();
     global.vitestPuppeteer = {


### PR DESCRIPTION
Addresses Vitest v4 warning:

https://github.com/vitest-dev/vitest/blob/ede1f39d60458f9ec1a98cf72b290677d65a7d80/packages/vitest/src/integrations/env/loader.ts#L90

Tested by running tests and seeing no warnings.

See #12 